### PR TITLE
Add experimental file upload support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,7 +14,7 @@ Contributors
 * Bart Driessen <https://github.com/Bart92>
 
 
-Free software: GNU Lesser General Public License v3
+Apache License 2.0
 
 Documentation: https://mllaunchpad.readthedocs.io.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,7 +41,8 @@ Unreleased
 * |Fixed| Correcting variable names in TEMPLATE_cfg.yml,
   `issue #43 <https://github.com/schuderer/mllaunchpad/issues/43>`_,
   by `Bart Driessen <https://github.com/Bart92>`_.
-
+* |Enhancement| Added file upload support (multipart/form-data, experimental),
+  `Andreas Schuderer <https://github.com/schuderer>`_.
 
 0.0.5 (2019-07-20)
 ------------------------------------------------------------------------------

--- a/examples/TEMPLATE_cfg.yml
+++ b/examples/TEMPLATE_cfg.yml
@@ -27,3 +27,4 @@ api:
   version: '0.0.1'  # use semantic versioning (breaking.adding.fix), first segment will be used in url as e.g. .../v1/...
   raml: TEMPLATE.raml
   preload_datasources: False  # Load datasources into memory before any predictions. Only makes sense with caching.
+  root_path: .  # (optional) set root directory in which Flasks looks for static, templates directories to serve.

--- a/examples/addition_cfg.yml
+++ b/examples/addition_cfg.yml
@@ -15,3 +15,4 @@ api:
   version: '0.0.1'  # use semantic versioning (breaking.adding.fix), first segment will be used in url as .../vX
   raml: addition.raml
   preload_datasources: False  # Load datasources into memory before any predictions. Only makes sense with caching.
+  root_path: .  # (optional) set root directory in which Flasks looks for static, templates directories to serve.

--- a/examples/complex_cfg.yml
+++ b/examples/complex_cfg.yml
@@ -77,3 +77,4 @@ api:
   version: '0.0.1'  # use semantic versioning (breaking.adding.fix), first segment will be used in url as .../vX
   raml: complex.raml
   preload_datasources: False  # Load datasources into memory before any predictions. Only makes sense with caching.
+  root_path: .  # (optional) set root directory in which Flasks looks for static, templates directories to serve.

--- a/examples/r_example.R
+++ b/examples/r_example.R
@@ -1,8 +1,8 @@
 # Train this example from the command line:
-# python -m launchpad -c r_example_cfg.yml -t
+# python -m mlaunchpad -c r_example_cfg.yml -t
 #
 # Start REST API:
-# python -m launchpad -c r_example_cfg.yml -a
+# python -m mlaunchpad -c r_example_cfg.yml -a
 #
 # Example API call:
 # http://127.0.0.1:5000/some/v0/varieties?sepal.length=4.9&sepal.width=2.4&petal.length=3.3&petal.width=1

--- a/examples/r_example_cfg.yml
+++ b/examples/r_example_cfg.yml
@@ -29,3 +29,4 @@ api:
   version: '0.0.1'  # use semantic versioning (breaking.adding.fix), first segment will be used in url as e.g. .../v1/...
   raml: r_example.raml
   preload_datasources: False  # Load datasources into memory before any predictions. Only makes sense with caching.
+  root_path: .  # (optional) set root directory in which Flasks looks for static, templates directories to serve.

--- a/examples/tree_cfg.yml
+++ b/examples/tree_cfg.yml
@@ -45,3 +45,4 @@ api:
   version: '0.0.2'  # use semantic versioning (breaking.adding.fix), first segment will be used in url as e.g. .../v1/...
   raml: tree.raml
   preload_datasources: True  # Load datasources into memory before any predictions. Only makes sense with caching.
+  root_path: .  # (optional) set root directory in which Flasks looks for static, templates directories to serve.

--- a/mllaunchpad/cli.py
+++ b/mllaunchpad/cli.py
@@ -101,7 +101,7 @@ def main():
             "'export LAUNCHPAD_CFG=addition_cfg.yml'"
             "'gunicorn -w 4 -b 127.0.0.1:5000 mllaunchpad.wsgi:application'"
         )
-        app = Flask(__name__)
+        app = Flask(__name__, root_path=conf["api"].get("root_path"))
         ModelApi(conf, app)
         app.run(debug=True)
     elif cmd == "genraml":

--- a/mllaunchpad/wsgi.py
+++ b/mllaunchpad/wsgi.py
@@ -28,7 +28,7 @@ try:
 
     # if you change the name of the application variable, you need to
     # specify it explicitly for gunicorn: gunicorn ... launchpad.wsgi:appname
-    application = Flask(__name__)
+    application = Flask(__name__, root_path=conf["api"].get("root_path"))
 
     ModelApi(conf, application)
 except FileNotFoundError:

--- a/requirements/examples.txt
+++ b/requirements/examples.txt
@@ -35,7 +35,7 @@ tensorflow
 gunicorn; sys_platform == 'darwin'
 # Removed rpy2 due to incompatibility of its wheel on Windows:
 # The conda install of 2.9.4 on Windows works (you have to adapt some code)
-#rpy2 ==2.9.4; sys_platform == 'win32'
-#rpy2 ==3.0.4; sys_platform == 'darwin'
+#rpy2==2.9.4; sys_platform == 'win32'
+#rpy2==3.0.4; sys_platform == 'darwin'
 # tzlocal is no requirement of launchpad but of rpy2.python2pi:
 #tzlocal

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `mllaunchpad.config` module."""
+
+# Stdlib imports
+from unittest import mock
+
+# Third-party imports
+import pytest
+
+# Application imports
+import mllaunchpad.config as config
+
+test_file_valid = b"""
+blabla:
+    - asdf
+    - adfs
+
+model:
+  name: my_model
+
+api:
+  name: my_api
+"""
+
+
+def test_get_config():
+    """Test Config loading."""
+    with mock.patch(
+        "%s.open" % config.__name__,
+        mock.mock_open(read_data=test_file_valid),
+        create=True,
+    ):
+        cfg = config.get_validated_config("lalala")
+        assert cfg["api"]["name"] == "my_api"
+        assert cfg["api"]["name"] == "my_api"
+
+
+def test_get_config_default_warning(caplog):
+    """Test Config loading."""
+    with mock.patch(
+        "%s.open" % config.__name__,
+        mock.mock_open(read_data=test_file_valid),
+        create=True,
+    ):
+        _ = config.get_validated_config()
+        assert "not set".lower() in caplog.text.lower()
+
+
+def test_get_config_invalid():
+    """Test config validation."""
+    test_file_invalid = b"""
+    blabla:
+        - asdf
+        - adfs
+
+    nomodel:
+      name: bla
+
+    api:
+      name: bla
+    """
+    with mock.patch(
+        "%s.open" % config.__name__,
+        mock.mock_open(read_data=test_file_invalid),
+        create=True,
+    ):
+        with pytest.raises(ValueError, match="does not contain"):
+            _ = config.get_validated_config("lalala")


### PR DESCRIPTION
* form-multipart only
* no server-side checks on file type or size yet

Example RAML:
```yaml
...

/topics:
 post:
    description: Upload a PDF file to predict the topic for.
    body:
      multipart/form-data:
        formParameters:
          text:  # just to demonstrate that form params are also possible together with files
            displayName: Optional alternative text of a client message
            type: string
            description: The plain text of a clients's letter, email, etc (uncleaned)
            required: false
        properties:
          file:
            description: The PDF file containing the client message, to be uploaded
            required: false
            type: file
            fileTypes: ["application/pdf"]  # Currently ignored by MLLP's validation
```

Example code:
```python
...

class SimpleTextClassifier(ModelInterface):
    """Simplest possible 'Data Science Model' example, without using data sources.
    """

    def predict(self, model_conf, data_sources, data_sinks, model, args_dict):
        if "file" in args_dict:
            logging.info("Predicting with file %s", args_dict["file"].filename)
            file = args_dict["file"].stream
            _, raw_text = pdf_to_txt(file)
            text = clean(raw_text)
        else:
            text = clean(args_dict['text'])
        labels = model.predict_proba([text])
        idx = np.argsort(labels * -1)
        topics = [int(label) for label in model.classes_[idx][0]]
        probs = labels[0][idx].tolist()[0]

        return {'topic': topics[0], 'topics': topics, 'probs': probs}
```

Addition:
The configuration for making Flask serve static pages/files is
```yaml
api:
  root_path: <some string>  # None by default
```