### PR TITLE
fix #61 - misleading error message "mllaunchpad/wsgi.py"

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,6 +13,7 @@ Contributors
 * Elisa Partodikromo <https://github.com/planeetjupyter>
 * Gosia Rorat <https://github.com/gosiarorat>
 * Bart Driessen <https://github.com/Bart92>
+* Bob Platte <https://github.com/bobplatte>
 
 Apache License 2.0
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,18 +25,19 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Unreleased
 ------------------------------------------------------------------------------
 
+* |Fixed| Fix misleading error message at WSGI entry point if model could
+  not be loaded,
+  `issue #61 <https://github.com/schuderer/mllaunchpad/issues/61>`_,
+  by `Bob Platte <https://github.com/bobplatte>`_.
 * |Enhancement| Config file is now being checked for omitted required keys,
   (no issue), by `Andreas Schuderer <https://github.com/schuderer>`_.
 * |Fixed| Use correct reference to werkzeug's FileStorage,
   `issue #63 <https://github.com/schuderer/mllaunchpad/issues/63>`_,
   by `Andreas Schuderer <https://github.com/schuderer>`_.
 
-0.0.7 (2020-02-21)
+0.0.7 (2020-01-28)
 ------------------------------------------------------------------------------
 
-* |Fixed| Fix misleading error message "mllaunchpad/wsgi.py",
-  `issue #61 <https://github.com/schuderer/mllaunchpad/issues/61>`_,
-  by `Bob Platte <https://github.com/bobplatte>`_.
 * |Fixed| Fix examples which could not be run on Windows,
   `issue #34 <https://github.com/schuderer/mllaunchpad/issues/34>`_,
   by `Andreas Schuderer <https://github.com/schuderer>`_.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,9 +31,12 @@ Unreleased
   `issue #63 <https://github.com/schuderer/mllaunchpad/issues/63>`_,
   by `Andreas Schuderer <https://github.com/schuderer>`_.
 
-0.0.7 (2020-01-28)
+0.0.7 (2020-02-21)
 ------------------------------------------------------------------------------
 
+* |Fixed| Fix misleading error message "mllaunchpad/wsgi.py",
+  `issue #61 <https://github.com/schuderer/mllaunchpad/issues/61>`_,
+  by `Bob Platte <https://github.com/bobplatte>`_.
 * |Fixed| Fix examples which could not be run on Windows,
   `issue #34 <https://github.com/schuderer/mllaunchpad/issues/34>`_,
   by `Andreas Schuderer <https://github.com/schuderer>`_.

--- a/mllaunchpad/wsgi.py
+++ b/mllaunchpad/wsgi.py
@@ -25,16 +25,20 @@ logger = logging.getLogger(__name__)
 # necessary to wrap the preparatory code in a try:except: statement.
 try:
     conf = config.get_validated_config()
-
-    # if you change the name of the application variable, you need to
-    # specify it explicitly for gunicorn: gunicorn ... launchpad.wsgi:appname
-    application = Flask(__name__, root_path=conf["api"].get("root_path"))
-
-    ModelApi(conf, application)
 except FileNotFoundError:
     logger.error(
         "Config file could not be loaded. Starting the Flask application "
         "will fail."
+    )
+
+    # if you change the name of the application variable, you need to
+    # specify it explicitly for gunicorn: gunicorn ... launchpad.wsgi:appname
+try:
+    application = Flask(__name__, root_path=conf["api"].get("root_path"))
+    ModelApi(conf, application)
+except FileNotFoundError:
+    logger.error(
+        "Previous model could not be loaded during the the ModelApi initialization."
     )
 
 if __name__ == "__main__":

--- a/mllaunchpad/wsgi.py
+++ b/mllaunchpad/wsgi.py
@@ -26,6 +26,10 @@ logger = logging.getLogger(__name__)
 try:
     conf = config.get_validated_config()
 except FileNotFoundError:
+    logger.error(
+        "Config file could not be loaded. Starting the Flask application "
+        "will fail."
+    )
     conf = None
 
     # if you change the name of the application variable, you need to

--- a/mllaunchpad/wsgi.py
+++ b/mllaunchpad/wsgi.py
@@ -26,27 +26,20 @@ logger = logging.getLogger(__name__)
 try:
     conf = config.get_validated_config()
 except FileNotFoundError:
-    logger.error(
-        "Config file could not be loaded. Starting the Flask application "
-        "will fail."
-    )
+    conf = None
 
     # if you change the name of the application variable, you need to
     # specify it explicitly for gunicorn: gunicorn ... launchpad.wsgi:appname
-try:
+if conf:
     application = Flask(__name__, root_path=conf["api"].get("root_path"))
     ModelApi(conf, application)
-except FileNotFoundError:
-    logger.error(
-        "Previous model could not be loaded during the the ModelApi initialization."
-    )
 
-if __name__ == "__main__":
-    logger.warning(
-        "Starting Flask debug server.\nIn production, please use a WSGI server, "
-        + "e.g. 'gunicorn -w 4 -b 127.0.0.1:5000 mllaunchpad.wsgi:application'"
-    )
-    application.run(debug=True)
+    if __name__ == "__main__":
+        logger.warning(
+            "Starting Flask debug server.\nIn production, please use a WSGI server, "
+            + "e.g. 'gunicorn -w 4 -b 127.0.0.1:5000 mllaunchpad.wsgi:application'"
+        )
+        application.run(debug=True)
 
 # To start an instance of production server with 4 workers:
 #  1. Set environment variables if required

--- a/mllaunchpad/wsgi.py
+++ b/mllaunchpad/wsgi.py
@@ -43,7 +43,9 @@ if conf:
             "Starting Flask debug server.\nIn production, please use a WSGI server, "
             + "e.g. 'gunicorn -w 4 -b 127.0.0.1:5000 mllaunchpad.wsgi:application'"
         )
-        application.run(debug=True)
+        # Flask apps must not be run in debug mode in production, because this allows for arbitrary code execution.
+        # We know that and advise the user that this is only for debugging, so this is not a security issue (marked nosec):
+        application.run(debug=True)  # nosec
 
 # To start an instance of production server with 4 workers:
 #  1. Set environment variables if required

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""Tests for `mllaunchpad.config` module."""
+"""Tests for `mllaunchpad.api` module."""
 
 # Stdlib imports
 from tempfile import NamedTemporaryFile

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `mllaunchpad.wsgi` module."""
+
+# Stdlib imports
+from importlib import reload
+from unittest.mock import patch
+
+# Third-party imports
+import pytest
+
+
+@patch("mllaunchpad.config.get_validated_config")
+def test_log_error_on_config_filenotfound(mock_get_cfg, caplog):
+    """Test that a FileNotFoundError on loading the config does
+    not cause an exception, but only log a 'not found, will fail' error.
+    """
+    mock_get_cfg.side_effect = FileNotFoundError
+
+    # This import is just to make sure the 'wsgi' symbol is known.
+    # We will ignore what happens and afterwards reload (re-import).
+    try:
+        import mllaunchpad.wsgi as wsgi  # pylint: disable=unused-import
+    except FileNotFoundError:
+        pass
+    # The proper "import" test:
+    reload(wsgi)
+    assert "will fail".lower() in caplog.text.lower()
+
+
+@patch("mllaunchpad.api.ModelApi")
+@patch("mllaunchpad.config.get_validated_config")
+def test_regression_61_misleading(mock_get_cfg, mock_get_api, caplog):
+    """Test that a FileNotFoundError on loading the Model does
+    cause a proper exception and not merely log a 'config not found' error.
+    https://github.com/schuderer/mllaunchpad/issues/61
+    """
+    mock_get_cfg.return_value = {"api": {}}
+    mock_get_api.side_effect = FileNotFoundError
+
+    # This import is just to make sure the 'wsgi' symbol is known.
+    # We will ignore what happens and afterwards reload (re-import).
+    try:
+        import mllaunchpad.wsgi as wsgi  # pylint: disable=unused-import
+    except FileNotFoundError:
+        pass
+    # The proper "import" test:
+    with pytest.raises(FileNotFoundError):
+        reload(wsgi)
+        assert "will fail".lower() not in caplog.text.lower()
+    assert mock_get_cfg.called


### PR DESCRIPTION
#61# Reference Issues/PRs
Amend try-catch block concerning config file load. add try-catch for loading previous model using the Flask application.

#### What does this implement/fix? Explain your changes.
The fix will make sure the proper error message is thrown when loading the config file and loading the previous model.

#### Other comments
No tests added to this draft pull request yet.