### PR TITLE
Deprecate api:version in config, using model:version instead.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Unreleased
 ------------------------------------------------------------------------------
 
+* |Deprecated| 'api:version:' to be removed from  configuration ('model:version:'
+  will be the only location to specify both the model and the API version),
+  `issue #66 <https://github.com/schuderer/mllaunchpad/issues/66>`_,
+  by `Andreas Schuderer <https://github.com/schuderer>`_.
 * |Fixed| Fix misleading error message at WSGI entry point if model could
   not be loaded,
   `issue #61 <https://github.com/schuderer/mllaunchpad/issues/61>`_,

--- a/examples/TEMPLATE_cfg.yml
+++ b/examples/TEMPLATE_cfg.yml
@@ -17,14 +17,13 @@ model_store:
 
 model:
   name: TemplateModel
-  version: '0.0.1'  # use semantic versioning (<breaking>.<adding>.<fix>)
+  version: '0.0.1'  # use semantic versioning (<breaking>.<adding>.<fix>), first segment will be used in url as e.g. .../v1/...
   module: TEMPLATE_model  # same as file name without .py
   train_options: {}
   predict_options: {}
 
 api:
   name: TEMPLATE  # name of the service api
-  version: '0.0.1'  # use semantic versioning (breaking.adding.fix), first segment will be used in url as e.g. .../v1/...
   raml: TEMPLATE.raml
   preload_datasources: False  # Load datasources into memory before any predictions. Only makes sense with caching.
   root_path: .  # (optional) set root directory in which Flasks looks for static, templates directories to serve.

--- a/examples/addition_cfg.yml
+++ b/examples/addition_cfg.yml
@@ -5,14 +5,13 @@ model_store:
 
 model:
   name: LameModel
-  version: '0.0.1'  # use semantic versioning (<breaking>.<adding>.<fix>)
+  version: '0.0.1'  # use semantic versioning (<breaking>.<adding>.<fix>), first segment will be used in url as .../vX
   module: addition_model  # same as file name without .py
   train_options: {}
   predict_options: {}
 
 api:
   name: add  # name of the service api, also what comes in the URL after the first /
-  version: '0.0.1'  # use semantic versioning (breaking.adding.fix), first segment will be used in url as .../vX
   raml: addition.raml
   preload_datasources: False  # Load datasources into memory before any predictions. Only makes sense with caching.
   root_path: .  # (optional) set root directory in which Flasks looks for static, templates directories to serve.

--- a/examples/complex_cfg.yml
+++ b/examples/complex_cfg.yml
@@ -67,14 +67,13 @@ model_store:
 
 model:
   name: AwesomeModel
-  version: '0.1.0'  # use semantic versioning (<breaking>.<adding>.<fix>)
+  version: '0.1.0'  # use semantic versioning (<breaking>.<adding>.<fix>), first segment will be used in url as e.g. .../v1/...
   module: complex_model  # same as file name without .py
   train_options: {magic_number: 13, num_ora_rows: 10}
   predict_options: {}
 
 api:
   name: guessiris  # name of the service api, also what comes in the URL after the first /
-  version: '0.0.1'  # use semantic versioning (breaking.adding.fix), first segment will be used in url as .../vX
   raml: complex.raml
   preload_datasources: False  # Load datasources into memory before any predictions. Only makes sense with caching.
   root_path: .  # (optional) set root directory in which Flasks looks for static, templates directories to serve.

--- a/examples/r_example_cfg.yml
+++ b/examples/r_example_cfg.yml
@@ -17,7 +17,7 @@ model_store:
 
 model:
   name: RExampleModel
-  version: '0.0.1'  # use semantic versioning (<breaking>.<adding>.<fix>)
+  version: '0.0.1'  # use semantic versioning (<breaking>.<adding>.<fix>), first segment will be used in url as e.g. .../v1/...
   module: r_model  # TODO: more flexible plugin support for this kind of thing
   r_file: r_example.R
   r_dependencies: [rpart]
@@ -26,7 +26,6 @@ model:
 
 api:
   name: some  # name of the service api
-  version: '0.0.1'  # use semantic versioning (breaking.adding.fix), first segment will be used in url as e.g. .../v1/...
   raml: r_example.raml
   preload_datasources: False  # Load datasources into memory before any predictions. Only makes sense with caching.
   root_path: .  # (optional) set root directory in which Flasks looks for static, templates directories to serve.

--- a/examples/tree_cfg.yml
+++ b/examples/tree_cfg.yml
@@ -35,14 +35,13 @@ model_store:
 
 model:
   name: IrisModel
-  version: '0.0.2'  # use semantic versioning (<breaking>.<adding>.<fix>)
+  version: '0.0.2'  # use semantic versioning (<breaking>.<adding>.<fix>), first segment will be used in url as e.g. .../v1/...
   module: tree_model  # same as file name without .py
   train_options: {}
   predict_options: {}
 
 api:
   name: iris  # name of the service api
-  version: '0.0.2'  # use semantic versioning (breaking.adding.fix), first segment will be used in url as e.g. .../v1/...
   raml: tree.raml
   preload_datasources: True  # Load datasources into memory before any predictions. Only makes sense with caching.
   root_path: .  # (optional) set root directory in which Flasks looks for static, templates directories to serve.

--- a/mllaunchpad/api.py
+++ b/mllaunchpad/api.py
@@ -25,11 +25,11 @@ logger = logging.getLogger(__name__)
 
 
 def _get_major_api_version(config):
-    match = re.match(r"\d+", config["api"]["version"])
+    match = re.match(r"\d+", config["model"]["version"])
     if match is None:
         raise ValueError(
-            "API version in configuration is malformed. Expected x.y.z, got {}".format(
-                config["api"]["version"]
+            "Model version in configuration is malformed. Expected x.y.z, got {}".format(
+                config["model"]["version"]
             )
         )
     return "v{}".format(match.group(0))

--- a/mllaunchpad/cli.py
+++ b/mllaunchpad/cli.py
@@ -54,14 +54,14 @@ def main():
         sys.exit(2)
     # evaluate given options
     cmd = None
-    conf = None
-    logger = None
+    conffile = None
+    logfile = None
     raml_ds = None
     for currentArgument, currentValue in arguments:
-        if currentArgument in ("-c", "--config"):
-            conf = lp.get_validated_config(currentValue)
-        elif currentArgument in ("-l", "--logconfig"):
-            logger = logutil.init_logging(currentValue)
+        if currentArgument in ("-l", "--logconfig"):
+            logfile = currentValue
+        elif currentArgument in ("-c", "--config"):
+            conffile = currentValue
         elif currentArgument in ("-t", "--train"):
             cmd = "train"
         elif currentArgument in ("-r", "--retest"):
@@ -85,8 +85,15 @@ def main():
         print(HELP_STRING, file=sys.stderr)
         exit(1)
 
-    logger = logger or logutil.init_logging()
-    conf = conf or lp.get_validated_config()
+    # Initialize logging before any other library code so that we can log stuff
+    logger = (
+        logutil.init_logging(logfile) if logfile else logutil.init_logging()
+    )
+    conf = (
+        lp.get_validated_config(conffile)
+        if conffile
+        else lp.get_validated_config()
+    )
     if cmd == "train":
         model, metrics = lp.train_model(conf)
     elif cmd == "retest":

--- a/mllaunchpad/config.py
+++ b/mllaunchpad/config.py
@@ -7,11 +7,13 @@
 # Stdlib imports
 import logging
 import os
+from warnings import warn
 
 # Third-party imports
 import yaml  # https://camel.readthedocs.io/en/latest/yamlref.html
 
 # Own project
+from mllaunchpad import __version__ as mllp_version
 from mllaunchpad.yaml_loader import Loader
 
 logger = logging.getLogger(__name__)
@@ -44,6 +46,24 @@ def validate_config(config_dict, required, path=""):
         validate_config(config_dict[item], required[item], path_start + item)
 
 
+def check_semantics(config_dict):
+    if "api" in config_dict and "version" in config_dict["api"]:
+        if mllp_version < "1.0.0":
+            warn(
+                "Specifying 'version' in the config's 'api' section is "
+                "deprecated and will lead to an error in mllaunchpad>=1.0.0. "
+                "Specify 'version' in the 'model' section instead. "
+                "Your 'api:version' value will be ignored.",
+                DeprecationWarning,
+            )
+            del config_dict["api"]["version"]
+        else:
+            raise ValueError(
+                "'api:version:' is not allowed in the config, "
+                "only 'model:version:'."
+            )
+
+
 def get_validated_config(filename=CONFIG_ENV):
     """Read the configuration from file and return it as a dict object.
 
@@ -70,6 +90,7 @@ def get_validated_config(filename=CONFIG_ENV):
         y = yaml.load(f, Loader)
 
     validate_config(y, required_config)
+    check_semantics(y)
 
     logger.debug("Configuration loaded and validated: %s", y)
 

--- a/mllaunchpad/logutil.py
+++ b/mllaunchpad/logutil.py
@@ -4,6 +4,7 @@
 import logging
 import logging.config
 import os
+import warnings
 
 # Third-party imports
 import yaml
@@ -16,6 +17,16 @@ LOG_CONF_FILENAME_ENV = os.environ.get(
 
 
 def init_logging(filename=LOG_CONF_FILENAME_ENV):
+    """Only called from wsgi or cli module (mllaunchpad-as-an-app).
+    It's important to not change logging/warning config from the library-only
+    code.
+    """
+    # Ignore all deprecation warnings:
+    warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+    # Except from mllaunchpad itself:
+    warnings.filterwarnings(
+        action="default", category=DeprecationWarning, module="mllaunchpad.*"
+    )
     if filename == "":
         logging.basicConfig(
             format="%(asctime)s %(levelname)s %(name)s: %(message)s",

--- a/mllaunchpad/resource.py
+++ b/mllaunchpad/resource.py
@@ -115,7 +115,6 @@ class ModelStore:
             "name": model_conf["name"],
             "version": model_conf["version"],
             "api_name": api_conf["name"],
-            "api_version": api_conf["version"],
             "created": datetime.now().strftime(DATE_FORMAT),
             "created_by": getpass.getuser(),
             "metrics": metrics,

--- a/mllaunchpad/wsgi.py
+++ b/mllaunchpad/wsgi.py
@@ -32,9 +32,9 @@ except FileNotFoundError:
     )
     conf = None
 
+if conf:
     # if you change the name of the application variable, you need to
     # specify it explicitly for gunicorn: gunicorn ... launchpad.wsgi:appname
-if conf:
     application = Flask(__name__, root_path=conf["api"].get("root_path"))
     ModelApi(conf, application)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 filterwarnings =
     ignore::DeprecationWarning:jinja2.*:
+    ignore::DeprecationWarning:watchdog.*:


### PR DESCRIPTION
Fixes  #66 

Only the config's `model:version` will be used in places where, before, `model:version` *and* `api:version` have *both* been used. In other words, `model:version` now also determines the `/v1/` part of the URL. There is now only one kind of version for an ML-Launchpad-implemented model.

Built in a conditional where for `mllaunchpad`<1.0.0 a DeprecationWarning will be given, and from `mllaunchpad`>=1.0.0, a ValueError will be thrown. Includes a unit test for the warning/error.

Changed the examples accordingly.

Also implements a small fix where warnings that used `warnings.warn()` have not been logged properly before, and adjusted the warning filter rules for cli/wsgi entry points to only display `mllaunchpad`'s own warnings.

