### PR TITLE
Updates to static code analysis and formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,20 +21,15 @@ language: python
 
 matrix:
   include:
-    # - python: '3.5'
-    #   env: NOXSESSIONS="tests-3.5"
     - python: '3.6'
       env: NOXSESSIONS="tests-3.6"
-    - python: '3.7'  # Also test docs with latest supported python version
+    - python: '3.8'  # Also test docs with latest supported python version
+      dist: xenial
+      env: NOXSESSIONS="tests-3.8"
+    - python: '3.7'
       dist: xenial  # required for Python >= 3.7
       env: NOXSESSIONS="coverage-3.7 lint docs"
-    # - python: '3.6'
-    #   env: NOXSESSIONS="tests-2.7"
-  # allow_failures:
-  #   - python: '3.6'
-  #     env: NOXSESSIONS="tests-2.7"
-  #   - python: '3.5'
-  #     env: NOXSESSIONS="tests-3.5"
+
 
 cache: pip
 

--- a/examples/TEMPLATE_model.py
+++ b/examples/TEMPLATE_model.py
@@ -1,8 +1,9 @@
-from mllaunchpad import ModelInterface, ModelMakerInterface
-from sklearn.metrics import accuracy_score, confusion_matrix
-from sklearn import tree
-import pandas as pd
 import logging
+
+from mllaunchpad import ModelInterface, ModelMakerInterface
+# from sklearn import tree
+# from sklearn.metrics import accuracy_score, confusion_matrix
+
 
 logger = logging.getLogger(__name__)
 
@@ -20,15 +21,19 @@ class MyExampleModelMaker(ModelMakerInterface):
     """Creates a model
     """
 
-    def create_trained_model(self, model_conf, data_sources, data_sinks, old_model=None):
-        df = data_sources['petals'].get_dataframe()
+    def create_trained_model(
+        self, model_conf, data_sources, data_sinks, old_model=None
+    ):
+        # df = data_sources["petals"].get_dataframe()
 
         ...
+        model = ...
 
         return model
 
     def test_trained_model(self, model_conf, data_sources, data_sinks, model):
         ...
+        metrics = ...
 
         return metrics
 
@@ -39,5 +44,6 @@ class MyExampleModel(ModelInterface):
 
     def predict(self, model_conf, data_sources, data_sinks, model, args_dict):
         ...
+        output = ...
 
         return output

--- a/examples/addition_model.py
+++ b/examples/addition_model.py
@@ -1,5 +1,7 @@
-from mllaunchpad import ModelInterface, ModelMakerInterface
 import logging
+
+from mllaunchpad import ModelInterface, ModelMakerInterface
+
 
 logger = logging.getLogger(__name__)
 
@@ -20,15 +22,19 @@ class MyAdditionExampleModelMaker(ModelMakerInterface):
     def create_trained_model(self, model_conf, data_sources, data_sinks, old_model=None):
 
         # We can get info from the model's config dictionary if necessary
-        my_name = model_conf['name']
-        logger.info('%s is doing lots of important preparation for addition...', my_name)
+        my_name = model_conf["name"]
+        logger.info(
+            "%s is doing lots of important preparation for addition...", my_name
+        )
 
         # Imagine we are preparing data and training a sklearn or some other model here
-        my_lame_predictor = lambda x1, x2: x1 + x2
+        def add(x1, x2):
+            return x1 + x2
+        my_lame_predictor = add
 
         # Usually, we put one or several trained regressors/classifiers into the
         # model, but in this example we just use our function.
-        model = {'lame_pred': my_lame_predictor}
+        model = {"lame_pred": my_lame_predictor}
         # In addition to regressors/classifiers/etc., you can also use this to
         # tell prediction about e.g. calculated parameters, thresholds, etc.
         # that have been calculated during the training process.
@@ -49,7 +55,7 @@ class MyAdditionExampleModelMaker(ModelMakerInterface):
         # Prediction happens here. Usually (though you *can*), you will not call
         # your own predict method, but get the inner model (classifier/regressor/...)
         # and use it directly.
-        lame_predictor = model['lame_pred']
+        lame_predictor = model["lame_pred"]
         y = lame_predictor(x1_test, x2_test)
 
         # Calculate some metrics
@@ -59,7 +65,7 @@ class MyAdditionExampleModelMaker(ModelMakerInterface):
         # don't invent new names for common test metrics that will possibly be read
         # automatically in the model's life cycle management. You can add new
         # metrics if you want, just don't invent abbreviations like 'acc' or such.
-        metrics = {'accuracy': acc, 'precision': 'whatever'}
+        metrics = {"accuracy": acc, "precision": "whatever"}
 
         return metrics
 
@@ -71,18 +77,18 @@ class MyAdditionExampleModel(ModelInterface):
     def predict(self, model_conf, data_sources, data_sinks, model, args_dict):
 
         # We can optionally get info from the model's config dictionary
-        my_name = model_conf['name']
-        logger.info('Hey, look at me, %s -- I\'m adding two numbers!', my_name)
+        my_name = model_conf["name"]
+        logger.info("Hey, look at me, %s -- I'm adding two numbers!", my_name)
 
         # Get the parameters/arguments from the API call
-        x1 = args_dict['x1']
-        x2 = args_dict['x2']
+        x1 = args_dict["x1"]
+        x2 = args_dict["x2"]
 
         # Get the predictor from the dict that we stuffed into this model when training
-        my_lame_predictor = model['lame_pred']
+        my_lame_predictor = model["lame_pred"]
 
         # Our sophisticated model does its magic here
         y = my_lame_predictor(x1, x2)
 
         # We usually return a dict with prediction results
-        return {'my_addition_result': y}
+        return {"my_addition_result": y}

--- a/examples/bogusdatasource.py
+++ b/examples/bogusdatasource.py
@@ -1,6 +1,8 @@
-import pandas as pd
-from mllaunchpad.resource import DataSource
 import logging
+
+from mllaunchpad.resource import DataSource
+import pandas as pd
+
 
 logger = logging.getLogger(__name__)
 
@@ -8,7 +10,8 @@ logger = logging.getLogger(__name__)
 class BogusDataSource(DataSource):
     """DataSource for creating nonsense
     """
-    serves = ['bogus']
+
+    serves = ["bogus"]
 
     # def __init__(self, identifier, datasource_config):
     #     super().__init__(identifier, datasource_config)
@@ -24,7 +27,7 @@ class BogusDataSource(DataSource):
             DataFrame object, possibly cached according to expires-config
         """
         if buffer:
-            raise NotImplementedError('Buffered reading not supported yet')
+            raise NotImplementedError("Buffered reading not supported yet")
 
         cached = self._try_get_cached_df()
         if cached is not None:
@@ -32,8 +35,7 @@ class BogusDataSource(DataSource):
 
         kw_options = self.options
 
-        return pd.DataFrame({'a': [3,4,5], 'b':[6,7,8]})
-
+        return pd.DataFrame({"a": [3, 4, 5], "b": [6, 7, 8]}, **kw_options)
 
     def get_raw(self, arg_dict=None, buffer=False):
         """Not implemented.
@@ -45,4 +47,4 @@ class BogusDataSource(DataSource):
         Returns:
             Nothing, throws NotImplementedError
         """
-        raise NotImplementedError('Raw bogus not supported yet')
+        raise NotImplementedError("Raw bogus not supported yet")

--- a/examples/complex_model.py
+++ b/examples/complex_model.py
@@ -1,8 +1,10 @@
+import logging
+
+from mllaunchpad import ModelInterface, ModelMakerInterface
 import pandas as pd
 from sklearn import tree
 from sklearn.metrics import accuracy_score, confusion_matrix
-from mllaunchpad import ModelInterface, ModelMakerInterface
-import logging
+
 
 logger = logging.getLogger(__name__)
 
@@ -27,39 +29,39 @@ class MyModelMaker(ModelMakerInterface):
 
     def create_trained_model(self, model_conf, data_sources, data_sinks, old_model=None):
         # demo: get the database data source
-        limit = model_conf['train_options']['num_ora_rows']
-        dbdf = data_sources['panel'].get_dataframe(arg_dict={'limit': limit})
+        limit = model_conf["train_options"]["num_ora_rows"]
+        dbdf = data_sources["panel"].get_dataframe(arg_dict={"limit": limit})
         print(dbdf)
 
         # just for lolz
-        number_to_add = model_conf['train_options']['magic_number']
+        number_to_add = model_conf["train_options"]["magic_number"]
         my_lame_predictor = lambda x: x + number_to_add
 
         # train a tree as a demo
-        df = data_sources['petals'].get_dataframe()
-        X_train = df.drop('variety', axis=1)
-        y_train = df['variety']
+        df = data_sources["petals"].get_dataframe()
+        X_train = df.drop("variety", axis=1)
+        y_train = df["variety"]
 
         # optional data prep/feature creation/refinement here...
         my_tree = tree.DecisionTreeClassifier()
         my_tree.fit(X_train, y_train)
 
-        model = {'lame_pred': my_lame_predictor, 'petal_pred': my_tree}
+        model = {"lame_pred": my_lame_predictor, "petal_pred": my_tree}
 
         return model
 
     def test_trained_model(self, model_conf, data_sources, data_sinks, model):
-        df = data_sources['petals_test'].get_dataframe()
-        X_test = df.drop('variety', axis=1)
-        y_test = df['variety']
+        df = data_sources["petals_test"].get_dataframe()
+        X_test = df.drop("variety", axis=1)
+        y_test = df["variety"]
 
-        my_tree = model['petal_pred']
+        my_tree = model["petal_pred"]
 
         y_predict = my_tree.predict(X_test)
 
         acc = accuracy_score(y_test, y_predict)
         conf = confusion_matrix(y_test, y_predict).tolist()
-        metrics = {'accuracy': acc, 'confusion_matrix': conf}
+        metrics = {"accuracy": acc, "confusion_matrix": conf}
 
         return metrics
 
@@ -69,28 +71,30 @@ class MyModel(ModelInterface):
     """
 
     def predict(self, model_conf, data_sources, data_sinks, model, args_dict):
-        logger.info('Hey, look at me -- I\'m carrying out a prediction')
+        logger.info("Hey, look at me -- I'm carrying out a prediction")
 
         # Do some lame prediction (= addition)
-        x_raw = args_dict['x']
+        x_raw = args_dict["x"]
 
         # optional data prep/feature creation for x here...
         x = data_prep(x_raw)
 
-        name_df = data_sources['first_names'].get_dataframe()
-        random_name = name_df.sample(n=1)['name'].values[0]
+        name_df = data_sources["first_names"].get_dataframe()
+        random_name = name_df.sample(n=1)["name"].values[0]
 
-        lame_predictor = ModelInterface()['lame_pred']
+        lame_predictor = ModelInterface()["lame_pred"]
         y = lame_predictor(x)
 
         # Also try iris petal-based prediction:
-        petal_predictor = model['petal_pred']
-        X2 = pd.DataFrame({
-            'sepal.length': [args_dict['sepal.length']],
-            'sepal.width': [args_dict['sepal.width']],
-            'petal.length': [args_dict['petal.length']],
-            'petal.width': [args_dict['petal.width']]
-            })
+        petal_predictor = model["petal_pred"]
+        X2 = pd.DataFrame(
+            {
+                "sepal.length": [args_dict["sepal.length"]],
+                "sepal.width": [args_dict["sepal.width"]],
+                "petal.length": [args_dict["petal.length"]],
+                "petal.width": [args_dict["petal.width"]],
+            }
+        )
         y2 = petal_predictor.predict(X2)[0]
 
-        return {'the_result_yo': y, 'random_name': random_name, 'iris_variety': y2}
+        return {"the_result_yo": y, "random_name": random_name, "iris_variety": y2}

--- a/examples/r_model.py
+++ b/examples/r_model.py
@@ -1,16 +1,19 @@
 import logging
+
+from mllaunchpad import ModelInterface, ModelMakerInterface
 import rpy2
+import rpy2.rinterface as ri
 import rpy2.robjects as ro
 import rpy2.robjects.packages as rp
-import rpy2.rinterface as ri
 from rpy2.robjects import pandas2ri
 # from rpy2.robjects import numpy2ri
-from mllaunchpad import ModelInterface, ModelMakerInterface
+
+
 logger = logging.getLogger(__name__)
 # numpy2ri.activate()  # vector=rpyn.ri2numpy(vector_R)
 pandas2ri.activate()  # If wishing to convert explicitly for any reason, the functions are pandas2ri.py2rpy() and pandas2ri.rpy2py (rpy2 >= 3.0.0) (rpy2 2.9.4: pandas2ri.py2ri() and pandas2ri.ri2py(), which earlier were pandas2ri.pandas2ri() and pandas2ri.ri2pandas())).
 
-if rpy2.__version__[0] == '2':  # tested with rpy2 == 2.9.4
+if rpy2.__version__[0] == "2":  # tested with rpy2 == 2.9.4
     rpy2_v2 = True
     py2rpy = pandas2ri.py2ri
     rpy2py = pandas2ri.ri2py
@@ -21,23 +24,25 @@ else:  # tested with rpy2 == 3.0.4
 
 
 def load_dependencies(model_conf):
-    if not hasattr(ro.r, 'loaded_r_model_dependencies'):
+    if not hasattr(ro.r, "loaded_r_model_dependencies"):
         utils = rp.importr("utils")
-        package_names = model_conf['r_dependencies']
+        package_names = model_conf["r_dependencies"]
         for pkg in package_names:
             loaded = ro.r.require(pkg)
             if not loaded[0]:
-                logger.info('R package %s is not installed. Installing...', pkg)
+                logger.info("R package %s is not installed. Installing...", pkg)
                 utils.install_packages(pkg)
-                logger.info('Loading freshly installed R package %s...', pkg)
+                logger.info("Loading freshly installed R package %s...", pkg)
                 ro.r.library(pkg)
-            logger.info('Loaded R dependency package %s', pkg)
-        ro.globalenv['loaded_r_model_dependencies'] = 1
+            logger.info("Loaded R dependency package %s", pkg)
+        ro.globalenv["loaded_r_model_dependencies"] = 1
 
 
 def source_r_file(model_conf):
-    if not hasattr(ro.r, 'create_trained_model') and not hasattr(ro.r, 'predict_with_trained_model'):
-        r_filename = model_conf['r_file']
+    if not hasattr(ro.r, "create_trained_model") and not hasattr(
+        ro.r, "predict_with_trained_model"
+    ):
+        r_filename = model_conf["r_file"]
         logger.info("Loading R source file: %s...", r_filename)
         ro.r.source(r_filename)
 
@@ -56,7 +61,9 @@ def r_list_to_dict(d):
         return d
     else:
         if rpy2_v2:
-            return {key: r_list_to_dict(d.rx2(key))[0] for key in d.names}  # rpy2 == 2.9.4
+            return {
+                key: r_list_to_dict(d.rx2(key))[0] for key in d.names
+            }  # rpy2 == 2.9.4
         else:
             return {key: r_list_to_dict(val[0]) for key, val in d.items()}
 
@@ -64,37 +71,48 @@ def r_list_to_dict(d):
 #  (rpy2 >= 3.0.x) Workaround to keep functions from being garbage-collected
 aref = None
 aref2 = None
+
+
 def prepare_r_data_sources_and_sinks(data_sources, data_sinks, kind):
     """Makes data source/sink access functions available in R environment
     """
-    if not hasattr(ro.r, 'created_data_sources_and_sinks_'+kind):
-        logger.debug("Creating R get_dataframe and put_dataframe functions for %s", kind)
+    if not hasattr(ro.r, "created_data_sources_and_sinks_" + kind):
+        logger.debug(
+            "Creating R get_dataframe and put_dataframe functions for %s", kind
+        )
 
         @ri.rternalize
         def get_dataframe(name_vec, arg_dict=None):
             name = name_vec[0]
-            logger.debug("Calling python DS %s's get_dataframe and returning R dataframe", name)
+            logger.debug(
+                "Calling python DS %s's get_dataframe and returning R dataframe", name
+            )
             pd_df = data_sources[name].get_dataframe(arg_dict)
             return py2rpy(pd_df)
 
         @ri.rternalize
         def put_dataframe(name_vec, r_df, arg_dict=None):
             name = name_vec[0]
-            logger.debug("Calling python DS %s's put_dataframe with ri2py converted pandas dataframe", name)
+            logger.debug(
+                "Calling python DS %s's put_dataframe with ri2py converted pandas dataframe",
+                name,
+            )
             df = rpy2py(r_df)
             data_sinks[name].put_dataframe(df, arg_dict)
 
-        ro.globalenv['get_dataframe'] = get_dataframe
-        ro.globalenv['put_dataframe'] = put_dataframe
+        ro.globalenv["get_dataframe"] = get_dataframe
+        ro.globalenv["put_dataframe"] = put_dataframe
 
         # (rpy2 >= 3.0.x) Workaround to keep functions from being garbage-collected
         global aref, aref2
         aref = get_dataframe
         aref2 = put_dataframe
 
-        ro.globalenv['created_data_sources_and_sinks_'+kind] = 1
+        ro.globalenv["created_data_sources_and_sinks_" + kind] = 1
     else:
-        logger.debug("Using existing R get_dataframe and put_dataframe functions for %s", kind)
+        logger.debug(
+            "Using existing R get_dataframe and put_dataframe functions for %s", kind
+        )
 
 
 class MyExampleModelMaker(ModelMakerInterface):
@@ -104,10 +122,10 @@ class MyExampleModelMaker(ModelMakerInterface):
     def create_trained_model(self, model_conf, data_sources, data_sinks, old_model=None):
         load_dependencies(model_conf)
         source_r_file(model_conf)
-        prepare_r_data_sources_and_sinks(data_sources, data_sinks, 'train')
+        prepare_r_data_sources_and_sinks(data_sources, data_sinks, "train")
 
         r_model_conf = dict_to_r_list(model_conf)
-        r_old_model = old_model if old_model is not None else ro.r('NULL')
+        r_old_model = old_model if old_model is not None else ro.r("NULL")
         logger.debug("Calling R function test_trained_model")
         model = ro.r.create_trained_model(r_model_conf, r_old_model)
         logger.debug("Returned from R function create_trained_model")
@@ -117,7 +135,7 @@ class MyExampleModelMaker(ModelMakerInterface):
     def test_trained_model(self, model_conf, data_sources, data_sinks, model):
         load_dependencies(model_conf)
         source_r_file(model_conf)
-        prepare_r_data_sources_and_sinks(data_sources, data_sinks, 'test')
+        prepare_r_data_sources_and_sinks(data_sources, data_sinks, "test")
 
         r_model_conf = dict_to_r_list(model_conf)
         r_model = model
@@ -136,7 +154,7 @@ class MyExampleModel(ModelInterface):
     def predict(self, model_conf, data_sources, data_sinks, model, args_dict):
         load_dependencies(model_conf)
         source_r_file(model_conf)
-        prepare_r_data_sources_and_sinks(data_sources, data_sinks, 'predict')
+        prepare_r_data_sources_and_sinks(data_sources, data_sinks, "predict")
 
         r_args_list = dict_to_r_list(dict(args_dict))
         r_model_conf = dict_to_r_list(model_conf)
@@ -146,6 +164,5 @@ class MyExampleModel(ModelInterface):
         logger.debug("Returned from R function predict_with_model")
 
         output = r_list_to_dict(r_output)
-
 
         return output

--- a/examples/records_datasources.py
+++ b/examples/records_datasources.py
@@ -1,9 +1,8 @@
 import logging
 
+from mllaunchpad.resource import DataSource, get_user_pw
 import records
 
-from mllaunchpad.resource import DataSource
-from mllaunchpad.resource import get_user_pw
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +11,15 @@ class RecordsDbDataSource(DataSource):
     """DataSource for a bunch of relational database types:
     RedShift, Postgres, MySQL, SQLite, Oracle, Microsoft SQL
     """
-    serves = ['dbms.oracle', 'dbms.redshift', 'dbms.postgres', 'dbms.mysql', 'dbms.sqlite', 'dbms.ms_sql']
+
+    serves = [
+        "dbms.oracle",
+        "dbms.redshift",
+        "dbms.postgres",
+        "dbms.mysql",
+        "dbms.sqlite",
+        "dbms.ms_sql",
+    ]
 
     def __init__(self, identifier, datasource_config, dbms_config):
         super().__init__(identifier, datasource_config)
@@ -20,15 +27,21 @@ class RecordsDbDataSource(DataSource):
         self.dbms_config = dbms_config
 
         logger.info(
-            "Establishing Records database connection for datasource {}...".format(self.id)
+            "Establishing Records database connection for datasource {}...".format(
+                self.id
+            )
         )
         # if "connect" not in dbms_config:
         #     raise ValueError(f'No connection string (property "connect") in datasource {self.id} config')
-        dbtype = dbms_config['type']
+        dbtype = dbms_config["type"]
         user, pw = get_user_pw(dbms_config)
-        host = dbms_config['host']
-        port = ":" + str(dbms_config['port']) if 'port' in dbms_config else ''
-        service_name = "/?service_name=" + dbms_config['service_name'] if 'service_name' in dbms_config else ''
+        host = dbms_config["host"]
+        port = ":" + str(dbms_config["port"]) if "port" in dbms_config else ""
+        service_name = (
+            "/?service_name=" + dbms_config["service_name"]
+            if "service_name" in dbms_config
+            else ""
+        )
         connection_string = f"{dbtype}://{user}:{pw}@{host}{port}{service_name}"
         self.db = records.Database(connection_string)
 
@@ -43,7 +56,7 @@ class RecordsDbDataSource(DataSource):
             DataFrame object, possibly cached according to expires-config
         """
         if buffer:
-            raise NotImplementedError('Buffered reading not supported yet')
+            raise NotImplementedError("Buffered reading not supported yet")
             # the resulting `rows` of a query provides a nice way to do this, though
 
         cached = self._try_get_cached_df()
@@ -60,7 +73,7 @@ class RecordsDbDataSource(DataSource):
             )
         )
         rows = self.db.query(query, fetchall=True, **params)
-        df = rows.export('df')
+        df = rows.export("df")
 
         self._cache_df_if_required(df)
 
@@ -76,7 +89,7 @@ class RecordsDbDataSource(DataSource):
         Returns:
             Nothing, throws NotImplementedError
         """
-        raise NotImplementedError('Raw data not supported')
+        raise NotImplementedError("Raw data not supported")
 
     # def __del__(self):
     #     if hasattr(self, "db"):

--- a/examples/tree_model.py
+++ b/examples/tree_model.py
@@ -1,8 +1,11 @@
-from mllaunchpad import ModelInterface, ModelMakerInterface
-from sklearn.metrics import accuracy_score, confusion_matrix
-from sklearn import tree
-import pandas as pd
 import logging
+
+# Third-party imports
+from mllaunchpad import ModelInterface, ModelMakerInterface
+import pandas as pd
+from sklearn import tree
+from sklearn.metrics import accuracy_score, confusion_matrix
+
 
 logger = logging.getLogger(__name__)
 
@@ -26,11 +29,13 @@ class MyExampleModelMaker(ModelMakerInterface):
     """Creates a model
     """
 
-    def create_trained_model(self, model_conf, data_sources, data_sinks, old_model=None):
+    def create_trained_model(
+        self, model_conf, data_sources, data_sinks, old_model=None
+    ):
 
-        df = data_sources['petals'].get_dataframe()
-        X = df.drop('variety', axis=1)
-        y = df['variety']
+        df = data_sources["petals"].get_dataframe()
+        X = df.drop("variety", axis=1)
+        y = df["variety"]
 
         my_tree = tree.DecisionTreeClassifier()
         my_tree.fit(X, y)
@@ -38,9 +43,9 @@ class MyExampleModelMaker(ModelMakerInterface):
         return my_tree
 
     def test_trained_model(self, model_conf, data_sources, data_sinks, model):
-        df = data_sources['petals_test'].get_dataframe()
-        X_test = df.drop('variety', axis=1)
-        y_test = df['variety']
+        df = data_sources["petals_test"].get_dataframe()
+        X_test = df.drop("variety", axis=1)
+        y_test = df["variety"]
 
         my_tree = model
 
@@ -49,7 +54,7 @@ class MyExampleModelMaker(ModelMakerInterface):
         acc = accuracy_score(y_test, y_predict)
         conf = confusion_matrix(y_test, y_predict).tolist()
 
-        metrics = {'accuracy': acc, 'confusion_matrix': conf}
+        metrics = {"accuracy": acc, "confusion_matrix": conf}
 
         return metrics
 
@@ -60,36 +65,41 @@ class MyExampleModel(ModelInterface):
 
     def predict(self, model_conf, data_sources, data_sinks, model, args_dict):
 
-        if 'test_key' in args_dict:
+        if "test_key" in args_dict:
             # URI param example (an uri param is part in the args_dict just like any other input)
-            key = args_dict['test_key']
-            logger.info('Got the uri parameter (ID) %s. Looking up input data and predicting...', key)
-            df = data_sources['batch_input'].get_dataframe()
-            df['myid'] = df['myid'].apply(str)
-            X = df.loc[df['myid'] == key]
+            key = args_dict["test_key"]
+            logger.info(
+                "Got the uri parameter (ID) %s. Looking up input data and predicting...",
+                key,
+            )
+            df = data_sources["batch_input"].get_dataframe()
+            df["myid"] = df["myid"].apply(str)
+            X = df.loc[df["myid"] == key]
             my_tree = model
-            y = my_tree.predict(X.drop('myid', axis=1))[0]
-            return {'iris_variety': y}
-        elif 'sepal.length' not in args_dict or args_dict['sepal.length'] is None:
+            y = my_tree.predict(X.drop("myid", axis=1))[0]
+            return {"iris_variety": y}
+        elif "sepal.length" not in args_dict or args_dict["sepal.length"] is None:
             # Batch prediction example
-            logger.info('Doing batch prediction')
-            X = data_sources['batch_input'].get_dataframe()
+            logger.info("Doing batch prediction")
+            X = data_sources["batch_input"].get_dataframe()
             my_tree = model
-            y = my_tree.predict(X.drop('myid', axis=1))
-            X['pred'] = y
-            data_sinks['predictions'].put_dataframe(X)
-            return {'status': 'ok'}
+            y = my_tree.predict(X.drop("myid", axis=1))
+            X["pred"] = y
+            data_sinks["predictions"].put_dataframe(X)
+            return {"status": "ok"}
 
         # "Normal" prediction example
         logger.info('Doing "normal" prediction')
-        X = pd.DataFrame({
-            'sepal.length': [args_dict['sepal.length']],
-            'sepal.width': [args_dict['sepal.width']],
-            'petal.length': [args_dict['petal.length']],
-            'petal.width': [args_dict['petal.width']]
-        })
+        X = pd.DataFrame(
+            {
+                "sepal.length": [args_dict["sepal.length"]],
+                "sepal.width": [args_dict["sepal.width"]],
+                "petal.length": [args_dict["petal.length"]],
+                "petal.width": [args_dict["petal.width"]],
+            }
+        )
 
         my_tree = model
         y = my_tree.predict(X)[0]
 
-        return {'iris_variety': y}
+        return {"iris_variety": y}

--- a/mllaunchpad/__init__.py
+++ b/mllaunchpad/__init__.py
@@ -1,12 +1,16 @@
 """Top-level package for ML Launchpad."""
 
+# Third-party imports
 import pkg_resources
 
-__version__ = pkg_resources.get_distribution("mllaunchpad").version
-
+# Project imports
 from mllaunchpad.config import get_validated_config
 from mllaunchpad.model_actions import predict, retest, train_model
 from mllaunchpad.model_interface import ModelInterface, ModelMakerInterface
+
+
+__version__ = pkg_resources.get_distribution("mllaunchpad").version
+
 
 # Get rid of stupid pyflakes warning (be warned: redundancy warning):
 __all__ = [

--- a/mllaunchpad/__main__.py
+++ b/mllaunchpad/__main__.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
-
 # Stdlib imports
 import sys
 
-# Application imports
+# Project imports
 import mllaunchpad.cli as cli
 
 

--- a/mllaunchpad/api.py
+++ b/mllaunchpad/api.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """This module contains functionality for generic creation
    and handling of RESTful APIs for Machine Learning Models.
    Among others, it handles parsing the RAML definition,
@@ -11,13 +9,13 @@ import logging
 import re
 
 # Third-party imports
-# from flask import Flask
-from flask_restful import Api, reqparse, Resource
 import ramlfications
+from flask_restful import Api, Resource, reqparse
 from werkzeug.datastructures import FileStorage
 
-# Application imports
+# Project imports
 from mllaunchpad import resource
+
 
 logger = logging.getLogger(__name__)
 

--- a/mllaunchpad/cli.py
+++ b/mllaunchpad/cli.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """This module provides the command line interface for ML Launchpad"""
 
 # Stdlib imports
@@ -9,11 +7,11 @@ import sys
 # Third-party imports
 from flask import Flask
 
-# Application imports
+# Project imports
 import mllaunchpad as lp
 from mllaunchpad import logutil
-from mllaunchpad.api import generate_raml
-from mllaunchpad.api import ModelApi
+from mllaunchpad.api import ModelApi, generate_raml
+
 
 HELP_STRING = """
 Parameters:

--- a/mllaunchpad/config.py
+++ b/mllaunchpad/config.py
@@ -5,6 +5,7 @@
 # Stdlib imports
 import logging
 import os
+from typing import Dict
 from warnings import warn
 
 # Third-party imports
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 CONFIG_DEFAULT = "./LAUNCHPAD_CFG.yml"
 CONFIG_ENV = os.environ.get("LAUNCHPAD_CFG", CONFIG_DEFAULT)
-required_config = {
+required_config: Dict[str, Dict] = {
     # datasources and datasinks are optional
     "model_store": {"location": {}},
     "model": {

--- a/mllaunchpad/config.py
+++ b/mllaunchpad/config.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """This module contains functionality for reading and validating the
    configuration.
 """
@@ -12,9 +10,10 @@ from warnings import warn
 # Third-party imports
 import yaml  # https://camel.readthedocs.io/en/latest/yamlref.html
 
-# Own project
-from mllaunchpad import __version__ as mllp_version
+# Project imports
+import mllaunchpad
 from mllaunchpad.yaml_loader import Loader
+
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +47,7 @@ def validate_config(config_dict, required, path=""):
 
 def check_semantics(config_dict):
     if "api" in config_dict and "version" in config_dict["api"]:
-        if mllp_version < "1.0.0":
+        if mllaunchpad.__version__ < "1.0.0":
             warn(
                 "Specifying 'version' in the config's 'api' section is "
                 "deprecated and will lead to an error in mllaunchpad>=1.0.0. "

--- a/mllaunchpad/logutil.py
+++ b/mllaunchpad/logutil.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Stdlib imports
 import logging
 import logging.config

--- a/mllaunchpad/model_actions.py
+++ b/mllaunchpad/model_actions.py
@@ -1,14 +1,13 @@
-# -*- coding: utf-8 -*-
-
 """Convenience functions for executing training, testing and prediction"""
 
 # Stdlib imports
 import logging
 import sys
 
-# Application imports
+# Project imports
 from mllaunchpad import resource
 from mllaunchpad.model_interface import ModelInterface, ModelMakerInterface
+
 
 logger = logging.getLogger(__name__)
 

--- a/mllaunchpad/model_interface.py
+++ b/mllaunchpad/model_interface.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
-
+# Stdlib imports
 import abc
 import logging
+
 
 logger = logging.getLogger(__name__)
 

--- a/mllaunchpad/resource.py
+++ b/mllaunchpad/resource.py
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
-
 # Stdlib imports
 import abc
-from datetime import datetime
 import getpass
 import glob
 import json
@@ -10,8 +7,9 @@ import logging
 import os
 import shutil
 import sys
-from time import time
 import typing
+from datetime import datetime
+from time import time
 from typing import Dict, Tuple, Type, TypeVar, Union
 
 # Third-party imports
@@ -20,6 +18,7 @@ from typing import Dict, Tuple, Type, TypeVar, Union
 import dill as pickle  # nosec
 import numpy as np
 import pandas as pd
+
 
 DS = TypeVar("DS", "DataSource", "DataSink")
 

--- a/mllaunchpad/wsgi.py
+++ b/mllaunchpad/wsgi.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """This module contains the WSGI app to start using a WSGI server like
    e.g. gunicorn or Apache with mod_wsgi.
 
@@ -13,10 +11,10 @@ import logging
 # Third-party imports
 from flask import Flask
 
-# Application imports
-from mllaunchpad import config
-from mllaunchpad import logutil
+# Project imports
+from mllaunchpad import config, logutil
 from mllaunchpad.api import ModelApi
+
 
 logutil.init_logging()
 logger = logging.getLogger(__name__)

--- a/mllaunchpad/yaml_loader.py
+++ b/mllaunchpad/yaml_loader.py
@@ -1,6 +1,7 @@
+# Stdlib imports
 import os
 
-# Third party import
+# Third-party imports
 import yaml
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -70,7 +70,7 @@ def lint(session):
 
 
 # In Travis-CI: session selected via env vars
-@nox.session(python=["3.6", my_py_ver])
+@nox.session(python=["3.6", my_py_ver, "3.8"])
 def tests(session):
     """Run the unit test suite"""
     session.install("-e", ".[test]")

--- a/noxfile.py
+++ b/noxfile.py
@@ -54,6 +54,7 @@ def lint(session):
     """Run code style and vulnerability checkers"""
     # session.install("-e", ".[lint]")  # so isort can detect everything automatically, but heavy install
     session.install(
+        "mypy",
         "isort",
         "seed-isort-config",
         "black",
@@ -61,6 +62,7 @@ def lint(session):
         "flake8-isort",
         "bandit",
     )
+    session.run("mypy", package_name)
     session.run("seed-isort-config", success_codes=[0, 1])
     session.run("black", "-l", max_line_length, "--check", *files_to_format)
     session.run(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore::DeprecationWarning:jinja2.*:
-    ignore::DeprecationWarning:watchdog.*:

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,11 +12,31 @@ exclude = docs
 # Ignore black styles.
 ignore = E501, W503
 # Imports
-import-order-style = google
-application-import-names = mllaunchpad,tests
+# import-order-style = google
+# application-import-names = mllaunchpad,tests
+
+[isort]
+atomic=true
+force_grid_wrap=0
+include_trailing_comma=true
+lines_after_imports=2
+lines_between_types=0
+multi_line_output=3
+not_skip=__init__.py,__main__.py
+use_parentheses=true
+import_heading_stdlib=Stdlib imports
+import_heading_thirdparty=Third-party imports
+import_heading_firstparty=Project imports
+known_first_party=mllaunchpad
+known_third_party=dill,flask,flask_restful,nox,numpy,pandas,pkg_resources,pytest,ramlfications,records,rpy2,setuptools,sklearn,werkzeug,yaml
+# known_third_party=pandas,numpy,flask,flask-restful,ramlfications,werkzeug,sklearn,dill,pyyaml,pytest
+# known_third_party=pytest  # rest is installed so isort can detect it
 
 [tool:pytest]
 collect_ignore = ['setup.py']
+filterwarnings =
+    ignore::DeprecationWarning:jinja2.*:
+    ignore::DeprecationWarning:watchdog.*:
 
 [metadata]
 name = mllaunchpad
@@ -54,9 +74,11 @@ python_requires = >= 3.6
 install_requires =
   flask
   flask-restful
+  werkzeug
   ramlfications
   dill
   pandas
+  numpy
   pyyaml
 
 [options.extras_require]
@@ -64,9 +86,11 @@ docs =
   sphinx
   sphinx-autobuild
 lint =
-  flake8
-  flake8-import-order
+  seed-isort-config
+  isort
   black
+  flake8
+  flake8-isort
   bandit
 release =
   twine
@@ -100,5 +124,5 @@ examples =
   #tzlocal
 
 [options.entry_points]
-  console_scripts =
-      mllaunchpad = mllaunchpad.cli:main
+console_scripts =
+  mllaunchpad = mllaunchpad.cli:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,11 @@ tag = True
 search = version = {current_version}
 replace = version = {new_version}
 
+[mypy]
+# Be lenient for now:
+disallow_untyped_defs = False
+ignore_missing_imports = True
+
 [flake8]
 exclude = docs
 # Ignore black styles.
@@ -89,6 +94,7 @@ lint =
   seed-isort-config
   isort
   black
+  mypy
   flake8
   flake8-isort
   bandit

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 """The setup script."""
 
+# Third-party imports
 from setuptools import setup
+
 
 setup()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 """Tests for `mllaunchpad.api` module."""
 
 # Stdlib imports
@@ -11,7 +8,7 @@ from unittest.mock import patch
 import pytest
 import ramlfications
 
-# Application imports
+# Project imports
 import mllaunchpad.api as api
 from mllaunchpad.model_interface import ModelInterface
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,16 +1,12 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 """Tests for `mllaunchpad.cli` module."""
 
 # Stdlib imports
 import sys
 
 # Third-party imports
-# from click.testing import CliRunner
 import pytest
 
-# Application imports
+# Project imports
 import mllaunchpad.cli as cli
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 """Tests for `mllaunchpad.config` module."""
 
 # Stdlib imports
@@ -9,9 +6,10 @@ from unittest import mock
 # Third-party imports
 import pytest
 
-# Application imports
-from mllaunchpad import __version__ as mllp_version
+# Project imports
+import mllaunchpad
 import mllaunchpad.config as config
+
 
 test_file_valid = b"""
 blabla:
@@ -149,7 +147,7 @@ def test_config_api_version_deprecation():
         mo,  # <-- use our mock variable here
         create=True,
     ):
-        if mllp_version < "1.0.0":
+        if mllaunchpad.__version__ < "1.0.0":
             with pytest.warns(DeprecationWarning):
                 _ = config.get_validated_config("lalala")
         else:

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,0 +1,75 @@
+"""Tests for `mllaunchpad.resource` module."""
+
+# Stdlib imports
+import json
+
+# Third-party imports
+import numpy as np
+import pandas as pd
+import pytest
+
+# Project imports
+from mllaunchpad import resource as r
+
+
+# fmt: off
+ndarray_examples = [
+    3,
+    [1, 2, 3],
+    [[1, 2], [3, 4]],
+    [[[1, 2]], [[3, 4]]],
+    [[.1, .2], [.3, .4]],
+]
+dataframe_examples = [
+    (pd.DataFrame(), {}),
+    (pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}),
+        {'x': {0: 1, 1: 2, 2: 3}, 'y': {0: 4, 1: 5, 2: 6}})
+]
+mixed_examples = [
+    ["a", 3, 3.7, [7], {"hello": 4, "something": ["else", "here", 12]}],
+    [np.array(e) for e in ndarray_examples],
+    {i: np.array(e) for i, e in enumerate(ndarray_examples)},
+    ["a", 3, np.array([4, 5]), pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})],
+]
+# fmt: on
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    zip([np.array(e) for e in ndarray_examples], ndarray_examples),
+)
+def test_to_plain_python_obj_numpy(test_input, expected):
+    """Test to convert numpy arrays to json-compatible object."""
+    output = r.to_plain_python_obj(test_input)
+    assert output == expected
+    # We should not get a json conversion error
+    json.dumps(output)
+
+
+@pytest.mark.parametrize("test_input,expected", dataframe_examples)
+def test_to_plain_python_obj_pandas(test_input, expected):
+    """Test to convert pandas arrays to json-compatible object."""
+    output = r.to_plain_python_obj(test_input)
+    assert output == expected
+    # We should not get a json conversion error
+    json.dumps(output)
+
+
+@pytest.mark.parametrize("test_input", mixed_examples)
+def test_to_plain_python_obj_mixed(test_input):
+    """Test to convert mixed arrays to json-compatible object."""
+    # It's enough that we don't get an exception here
+    output = r.to_plain_python_obj(test_input)
+    # We should not get a json conversion error
+    json.dumps(output)
+
+
+def test_to_plain_python_obj_error():
+    """Test the error case."""
+
+    class FailingObject:
+        pass
+
+    output = r.to_plain_python_obj(FailingObject())
+    with pytest.raises(TypeError):
+        json.dumps(output)

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 """Tests for `mllaunchpad.wsgi` module."""
 
 # Stdlib imports

--- a/tests/test_yaml_loader.py
+++ b/tests/test_yaml_loader.py
@@ -1,16 +1,14 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 """Tests for `mllaunchpad.yaml_loader module."""
 
 # Stdlib imports
 from unittest import mock
 
-# Third party
+# Third-party imports
 import yaml
 
-# Application imports
+# Project imports
 import mllaunchpad.yaml_loader as yloader
+
 
 test_file_yaml = b"""
     dbms: !include test


### PR DESCRIPTION
Working towards more/better automation in the dev/PR process (inspired by https://hynek.me/talks/python-foss/, among other sources).

First step was to automate import ordering with `isort`. Having them checked automatically was nice, but fixing and manual alphabetic ordering is not that fun of a pasttime. To this end, did the following:
* remove utf8 at beginning of files
* move pytest config to setup.cfg
* add isort-related requirements to extra [lint]
* add isort to nox
* change format nox session to static (no full install)
* configure isort in setup.cfg
* apply isort to all source code
* fix error with mllaunchpad.__version__ import at an inconvenient time
* make example code a little neater

Planning to tackle #80 (types with `mypy`) next.