### PR TITLE
Add `chunksize` param (buffered reading) to builtin datasources

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,9 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Unreleased
 ------------------------------------------------------------------------------
 
+* |Enhancement| Added ``chunksize`` parameter for piecemeal data reading to builtin DataSources,
+  `issue #120 <https://github.com/schuderer/mllaunchpad/issues/120>`_,
+  by `Andreas Schuderer <https://github.com/schuderer>`_.
 * |Enhancement| Added functionality to better support unit testing in model development
   (added optional parameters to :meth:`mllaunchpad.train_model`, :meth:`mllaunchpad.retest`
   and :meth:`mllaunchpad.predict`, added :meth:`mllaunchpad.get_validated_config_str`),

--- a/examples/bogusdatasource.py
+++ b/examples/bogusdatasource.py
@@ -16,7 +16,7 @@ class BogusDataSource(DataSource):
     # def __init__(self, identifier, datasource_config):
     #     super().__init__(identifier, datasource_config)
 
-    def get_dataframe(self, params=None, buffer=False):
+    def get_dataframe(self, params=None, chunksize=None):
         """Get some pandas dataframe.
 
         Params:
@@ -26,14 +26,14 @@ class BogusDataSource(DataSource):
         Returns:
             DataFrame object, possibly cached according to expires-config
         """
-        if buffer:
+        if chunksize:
             raise NotImplementedError("Buffered reading not supported yet")
 
         kw_options = self.options
 
         return pd.DataFrame({"a": [3, 4, 5], "b": [6, 7, 8]}, **kw_options)
 
-    def get_raw(self, params=None, buffer=False):
+    def get_raw(self, params=None, chunksize=None):
         """Not implemented.
 
         Params:

--- a/examples/impala_datasource.py
+++ b/examples/impala_datasource.py
@@ -82,7 +82,7 @@ class ImpalaDataSource(DataSource):
 
         self.dbms_config = new_dbms_config
 
-    def get_dataframe(self, params=None, buffer=False):
+    def get_dataframe(self, params=None, chunksize=None):
         """Get data as a pandas dataframe.
 
         Example::
@@ -91,12 +91,12 @@ class ImpalaDataSource(DataSource):
 
         :param params: Query parameters to fill in query (e.g. `:id` with value 387)
         :type params: optional dict
-        :param buffer: Currently not implemented
-        :type buffer: optional bool
+        :param chunksize: Currently not implemented
+        :type chunksize: optional bool
 
         :return: DataFrame object, possibly cached according to expires-config
         """
-        if buffer:
+        if chunksize:
             raise NotImplementedError('Buffered reading not supported yet')
 
         # Open connection
@@ -122,13 +122,13 @@ class ImpalaDataSource(DataSource):
 
         return df
 
-    def get_raw(self, params=None, buffer=False):
+    def get_raw(self, params=None, chunksize=None):
         """Not implemented.
 
         :param params: Query parameters to fill in query (e.g. `:id` with value 387)
         :type params: optional dict
-        :param buffer: Currently not implemented
-        :type buffer: optional bool
+        :param chunksize: Currently not implemented
+        :type chunksize: optional bool
 
         :raises NotImplementedError:
 

--- a/examples/records_datasource.py
+++ b/examples/records_datasource.py
@@ -78,7 +78,7 @@ class RecordsDbDataSource(DataSource):
         connection_string = f"{dbtype}://{user}:{pw}@{host}{port}{service_name}"
         self.db = records.Database(connection_string, **kwargs)
 
-    def get_dataframe(self, params=None, buffer=False):
+    def get_dataframe(self, params=None, chunksize=None):
         """Get data as a pandas dataframe.
 
         Example::
@@ -87,12 +87,12 @@ class RecordsDbDataSource(DataSource):
 
         :param params: Query parameters to fill in query (e.g. `:id` with value 387)
         :type params: optional dict
-        :param buffer: Currently not implemented
-        :type buffer: optional bool
+        :param chunksize: Currently not implemented
+        :type chunksize: optional bool
 
         :return: DataFrame object, possibly cached according to expires-config
         """
-        if buffer:
+        if chunksize:
             raise NotImplementedError("Buffered reading not supported yet")
             # the resulting `rows` of a query provides a nice way to do this, though
 
@@ -109,13 +109,13 @@ class RecordsDbDataSource(DataSource):
 
         return df
 
-    def get_raw(self, params=None, buffer=False):
+    def get_raw(self, params=None, chunksize=None):
         """Not implemented.
 
         :param params: Query parameters to fill in query (e.g. `:id` with value 387)
         :type params: optional dict
-        :param buffer: Currently not implemented
-        :type buffer: optional bool
+        :param chunksize: Currently not implemented
+        :type chunksize: optional bool
 
         :raises NotImplementedError:
 

--- a/mllaunchpad/datasources.py
+++ b/mllaunchpad/datasources.py
@@ -1,7 +1,6 @@
 # Stdlib imports
 import logging
-import os
-from typing import Dict, Generator, Iterable, Optional, Union, cast
+from typing import Dict, Generator, Optional, Union, cast
 
 # Third-party imports
 import numpy as np

--- a/mllaunchpad/datasources.py
+++ b/mllaunchpad/datasources.py
@@ -1,6 +1,7 @@
 # Stdlib imports
 import logging
-from typing import Dict, cast
+import os
+from typing import Dict, Generator, Iterable, Optional, Union, cast
 
 # Third-party imports
 import numpy as np
@@ -79,8 +80,8 @@ class OracleDataSource(DataSource):
         self.connection = _get_oracle_connection(dbms_config)
 
     def get_dataframe(
-        self, params: Dict = None, buffer: bool = False
-    ) -> pd.DataFrame:
+        self, params: Dict = None, chunksize: Optional[int] = None
+    ) -> Union[pd.DataFrame, Generator]:
         """Get the data as pandas dataframe.
 
         Example::
@@ -89,32 +90,43 @@ class OracleDataSource(DataSource):
 
         :param params: Query parameters to fill in query (e.g. replace query's `:id` parameter with value `387`)
         :type params: optional dict
-        :param buffer: Currently not implemented
-        :type buffer: optional bool
+        :param chunksize: Return an iterator where chunksize is the number of rows to include in each chunk.
+        :type chunksize: optional int
 
         :return: DataFrame object, possibly cached according to config value of `expires:`
         """
-        if buffer:
-            raise NotImplementedError("Buffered reading not supported yet")
-
         # TODO: maybe want to open/close connection on every method call (shouldn't happen often)
         query = self.config["query"]
         params = params or {}
         kw_options = self.options
 
         logger.debug(
-            "Fetching query {} with params {} and options {}...".format(
-                query, params, kw_options
+            "Fetching query {} with params {}, chunksize {}, and options {}...".format(
+                query, params, chunksize, kw_options
             )
         )
         df = pd.read_sql(
-            query, con=self.connection, params=params, **kw_options
+            query,
+            con=self.connection,
+            params=params,
+            chunksize=chunksize,
+            **kw_options
         )
-        df.fillna(np.nan, inplace=True)
+        if chunksize:
 
-        return df
+            def wrapped_iterator(data):
+                for partial_df in data:
+                    partial_df.fillna(np.nan, inplace=True)
+                    yield partial_df
 
-    def get_raw(self, params: Dict = None, buffer: bool = False) -> Raw:
+            return wrapped_iterator(df)
+        else:
+            df.fillna(np.nan, inplace=True)
+            return df
+
+    def get_raw(
+        self, params: Dict = None, chunksize: Optional[int] = None
+    ) -> Raw:
         """Not implemented.
 
         :raises NotImplementedError: Raw/blob format currently not supported.
@@ -192,8 +204,8 @@ class FileDataSource(DataSource):
         self.path = datasource_config["path"]
 
     def get_dataframe(
-        self, params: Dict = None, buffer: bool = False
-    ) -> pd.DataFrame:
+        self, params: Dict = None, chunksize: Optional[int] = None
+    ) -> Union[pd.DataFrame, Generator]:
         """Get data as a pandas dataframe.
 
         Example::
@@ -202,25 +214,31 @@ class FileDataSource(DataSource):
 
         :param params: Currently not implemented
         :type params: optional dict
-        :param buffer: Currently not implemented
-        :type buffer: optional bool
+        :param chunksize: Return an iterator where chunksize is the number of rows to include in each chunk.
+        :type chunksize: optional int
 
         :return: DataFrame object, possibly cached according to config value of `expires:`
         """
-        if buffer:
-            raise NotImplementedError("Buffered reading not supported yet")
+        if params:
+            raise NotImplementedError("Parameters not supported yet")
 
         kw_options = self.options
 
         logger.debug(
-            "Loading type {} file {} with options {}...".format(
-                self.type, self.path, kw_options
+            "Loading type {} file {} with chunksize {} and options {}...".format(
+                self.type, self.path, chunksize, kw_options
             )
         )
         if self.type == "csv":
-            df = pd.read_csv(self.path, **kw_options)
+            df = pd.read_csv(self.path, chunksize=chunksize, **kw_options)
         elif self.type == "euro_csv":
-            df = pd.read_csv(self.path, sep=";", decimal=",", **kw_options)
+            df = pd.read_csv(
+                self.path,
+                sep=";",
+                decimal=",",
+                chunksize=chunksize,
+                **kw_options
+            )
         else:
             raise TypeError(
                 'Can only read csv files as dataframes. Use method "get_raw" for raw data'
@@ -228,7 +246,9 @@ class FileDataSource(DataSource):
 
         return df
 
-    def get_raw(self, params: Dict = None, buffer: bool = False) -> Raw:
+    def get_raw(
+        self, params: Dict = None, chunksize: Optional[int] = None
+    ) -> Raw:
         """Get data as raw (unstructured) data.
 
         Example::
@@ -237,13 +257,15 @@ class FileDataSource(DataSource):
 
         :param params: Currently not implemented
         :type params: optional dict
-        :param buffer: Currently not implemented
-        :type buffer: optional bool
+        :param chunksize: Currently not implemented
+        :type chunksize: optional bool
 
         :return: The file's bytes (binary) or string (text) contents, possibly cached according to config value of `expires:`
         :rtype: bytes or str
         """
-        if buffer:
+        if params:
+            raise NotImplementedError("Parameters not supported yet")
+        if chunksize:
             raise NotImplementedError("Buffered reading not supported yet")
 
         kw_options = self.options
@@ -333,7 +355,7 @@ class FileDataSink(DataSink):
         self,
         dataframe: pd.DataFrame,
         params: Dict = None,
-        buffer: bool = False,
+        chunksize: Optional[int] = None,
     ) -> None:
         """Write a pandas dataframe to file.
         The default is not to save the dataframe's row index.
@@ -347,10 +369,12 @@ class FileDataSink(DataSink):
         :type dataframe: pandas DataFrame
         :param params: Currently not implemented
         :type params: optional dict
-        :param buffer: Currently not implemented
-        :type buffer: optional bool
+        :param chunksize: Currently not implemented
+        :type chunksize: optional bool
         """
-        if buffer:
+        if params:
+            raise NotImplementedError("Parameters not supported yet")
+        if chunksize:
             raise NotImplementedError("Buffered writing not supported yet")
 
         kw_options = self.options
@@ -372,7 +396,10 @@ class FileDataSink(DataSink):
             )
 
     def put_raw(
-        self, raw_data: Raw, params: Dict = None, buffer: bool = False,
+        self,
+        raw_data: Raw,
+        params: Dict = None,
+        chunksize: Optional[int] = None,
     ) -> None:
         """Write raw (unstructured) data to file.
 
@@ -384,10 +411,12 @@ class FileDataSink(DataSink):
         :type raw_data: bytes or str
         :param params: Currently not implemented
         :type params: optional dict
-        :param buffer: Currently not implemented
-        :type buffer: optional bool
+        :param chunksize: Currently not implemented
+        :type chunksize: optional bool
         """
-        if buffer:
+        if params:
+            raise NotImplementedError("Parameters not supported yet")
+        if chunksize:
             raise NotImplementedError("Buffered writing not supported yet")
 
         kw_options = self.options
@@ -460,7 +489,7 @@ class OracleDataSink(DataSink):
         self,
         dataframe: pd.DataFrame,
         params: Dict = None,
-        buffer: bool = False,
+        chunksize: Optional[int] = None,
     ) -> None:
         """Store the pandas dataframe as a table.
         The default is not to store the dataframe's row index.
@@ -474,10 +503,10 @@ class OracleDataSink(DataSink):
         :type dataframe: pandas DataFrame
         :param params: Currently not implemented
         :type params: optional dict
-        :param buffer: Currently not implemented
-        :type buffer: optional bool
+        :param chunksize: Currently not implemented
+        :type chunksize: optional bool
         """
-        if buffer:
+        if chunksize:
             raise NotImplementedError("Buffered storing not supported yet")
 
         # TODO: maybe want to open/close connection on every method call (shouldn't happen often)
@@ -494,7 +523,7 @@ class OracleDataSink(DataSink):
         dataframe.to_sql(table, con=self.connection, **kw_options)
 
     def put_raw(
-        self, raw_data, params: str = None, buffer: bool = False
+        self, raw_data, params: Dict = None, chunksize: Optional[int] = None
     ) -> None:
         """Not implemented.
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -83,6 +83,6 @@ def test_impaladatasource_notimplemented(impaladatasource_cfg_and_data):
 
     ds = imp.ImpalaDataSource("bla", cfg, dbms_cfg)
     with pytest.raises(NotImplementedError):
-        ds.get_dataframe(buffer=True)
+        ds.get_dataframe(chunksize=True)
     with pytest.raises(NotImplementedError, match="get_dataframe"):
         ds.get_raw()


### PR DESCRIPTION
You can now read dataframes from CSVs and Oracle in chunks of ``chunksize`` lines each. Example:
```python
df_iter = data_sources["my_datasource"].get_dataframe(chunksize=100)
for df in df_iter:
    incrementally_train(df)
```

If you use this to save on memory, keep in mind the general best practices that apply to concatenating dataframes, i.e. (1) try to avoid it and work with the data piece by piece, and (2) if you need everything in one DF, concatenate only once using ``pd.concat(df_iter)`` instead of concatenating in a loop.