### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,15 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 .. |Deprecated| replace:: :raw-html:`<span style="font-family: Sans-Serif; font-size: 0.6em; color: white; font-weight: bold; padding: 0.05em; border-radius: 0.2em; display: inline-block; background-color: orange">&nbsp;DEPRECATED&nbsp;</span>`
 .. |Removed| replace:: :raw-html:`<span style="font-family: Sans-Serif; font-size: 0.6em; color: white; font-weight: bold; padding: 0.05em; border-radius: 0.2em; display: inline-block; background-color: black">&nbsp;REMOVED&nbsp;</span>`
 
+.. Placeholder for empty Unreleased section:
+   * No contributions yet. :doc:`Be the first to add one! <contributing>`_ :)
+
 Unreleased
+------------------------------------------------------------------------------
+
+* No contributions yet. :doc:`Be the first to add one! <contributing>` :)
+
+1.0.0 (2020-06-08)
 ------------------------------------------------------------------------------
 
 * |Fixed| ``mllaunchpad --verbose`` now correctly logs DEBUG information,
@@ -46,10 +54,6 @@ Unreleased
   Microsoft SQL (ODBC), and their dialects,
   `issue #121 <https://github.com/schuderer/mllaunchpad/issues/121>`_,
   by `Andreas Schuderer <https://github.com/schuderer>`_.
-
-1.0.0rc1 (2020-04-29)
-------------------------------------------------------------------------------
-
 * |Enhancement| New command line interface (usage changes only slightly, see issue),
   `issue #77 <https://github.com/schuderer/mllaunchpad/issues/77>`_,
   by `Andreas Schuderer <https://github.com/schuderer>`_.
@@ -61,6 +65,7 @@ Unreleased
 * |Removed| Removed 'api:version:' (deprecated since 0.1.0) from  configuration
   ('model:version:' is now the only location to specify both the model and the API version),
   `issue #66 <https://github.com/schuderer/mllaunchpad/issues/66>`_,
+  by `Andreas Schuderer <https://github.com/schuderer>`_.
 
 0.1.2 (2020-04-23)
 ------------------------------------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ filterwarnings =
 
 [metadata]
 name = mllaunchpad
-version = 1.0.0rc1
+version = 1.0.0
 url = https://github.com/schuderer/mllaunchpad/
 project_urls =
   Documentation = https://mllaunchpad.readthedocs.io/


### PR DESCRIPTION
1.0.0 (2020-06-08)
 FIXED  mllaunchpad --verbose now correctly logs DEBUG information, issue #119, by Andreas Schuderer.

 FIXED  Fixed an issue where builtin DataSources could not be found when configured, issue #118, by Andreas Schuderer.

 FIXED  Readthedocs now shows the up-to-date API docs, issue #110, by Andreas Schuderer.

 ENHANCEMENT  Added chunksize parameter for piecemeal data reading to builtin DataSources, issue #120, by Andreas Schuderer.

 FEATURE  Added functionality to better support unit testing in model development (added optional parameters to mllaunchpad.train_model(), mllaunchpad.retest() and mllaunchpad.predict(), added mllaunchpad.get_validated_config_str()), issue #116, by Andreas Schuderer.

 FEATURE  Added generic SqlDataSource for RedShift, Postgres, MySQL, SQLite, Oracle, Microsoft SQL (ODBC), and their dialects, issue #121, by Andreas Schuderer.

Already published in pre-release 1.0.0rc1:

 ENHANCEMENT  New command line interface (usage changes only slightly, see issue), issue #77, by Andreas Schuderer.

 ENHANCEMENT  DataSource caching overhaul: data cached separately for different params, configurable cache_size, issue #97, by Andreas Schuderer.

 REMOVED  Removed ‘api:version:’ (deprecated since 0.1.0) from configuration (‘model:version:’ is now the only location to specify both the model and the API version), issue #66,