### PR TITLE
add optional addition of Flask host and port

### DIFF
--- a/mllaunchpad/cli.py
+++ b/mllaunchpad/cli.py
@@ -127,8 +127,8 @@ def api(settings):
     # Flask apps must not be run in debug mode in production, because this allows for arbitrary code execution.
     # We know that and advise the user that this is only for debugging, so this is not a security issue (marked nosec):
     app.run(
-        host=settings.config["api"].get("host"),
-        port=settings.config["api"].get("port"),
+        host=settings.config["api"].get("debug-host"),
+        port=settings.config["api"].get("debug-port"),
         debug=True
     )  # nosec
 

--- a/mllaunchpad/cli.py
+++ b/mllaunchpad/cli.py
@@ -126,7 +126,11 @@ def api(settings):
     ModelApi(settings.config, app, debug=True)
     # Flask apps must not be run in debug mode in production, because this allows for arbitrary code execution.
     # We know that and advise the user that this is only for debugging, so this is not a security issue (marked nosec):
-    app.run(debug=True)  # nosec
+    app.run(
+        host=settings.config["api"].get("host"),
+        port=settings.config["api"].get("port"),
+        debug=True
+    )  # nosec
 
 
 @main.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,7 +114,8 @@ def test_api(ma, flask, config, runner_cfg_logcfg, caplog):
     )  # Non-production Flask server warning
     flask.assert_called()
     ma.assert_called_with(config, app, debug=True)
-    app.run.assert_called()
+    app.run.assert_called_once()
+    assert list(app.run.call_args[1].keys()) == ["host", "port", "debug"]
 
 
 @mock.patch(


### PR DESCRIPTION
#### What this implements/fixes
Very straight forward implementation to optionally configure HOST and PORT to run the application on

